### PR TITLE
Детект большего кол-ва конфигураций для 1c-enterprise-users.yaml

### DIFF
--- a/1c-enterprise-users.yaml
+++ b/1c-enterprise-users.yaml
@@ -6,6 +6,10 @@ info:
   severity: medium
   description: Get list of users from 1C Enterprise server
   tags: misc,1c,1c_enterprise
+  metadata:
+    verified: true
+    max-request: 2
+    shodan-query: http.title:"1C:Enterprise"
 
 http:
   - raw:
@@ -16,17 +20,15 @@ http:
       - |
         GET /{{basepath}}/e1cib/users HTTP/1.1
         Host: {{Hostname}}
-        Content-Type: application/x-www-form-urlencoded
 
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          - contains(body_1, 'var VENDORPREFIX = \"1c\.\"')
           - status_code_2 == 200
           - contains(content_type_2, 'text/plain')
           - content_length_2 > 3
-          - "contains(tolower(header_2), 'vrs-rc')"
+          - contains(tolower(header_2), 'vrs-rc')
         condition: and
 
     extractors:
@@ -34,7 +36,7 @@ http:
         name: basepath
         group: 1
         regex:
-          - 'var BASE = "(.+)"'
+          - '[Vv][Aa][Rr] [Bb][Aa][Ss][Ee] = "(.+)"'
         internal: true
         part: body
 


### PR DESCRIPTION
Добавил регистронезависимый поиск пути, убрана проверка body_1. 
Данная проверка была удалена поскольку body_1 во время второго запроса перезатирается на части ресурсов и матчер не отрабатывает.