### PR TITLE
Parse detect url swagger-ui-xss.yaml

### DIFF
--- a/swagger-ui-xss.yaml
+++ b/swagger-ui-xss.yaml
@@ -49,4 +49,4 @@ headless:
     extractors:
       - type: dsl
         dsl:
-          - reflected_text_query_type
+          - matched


### PR DESCRIPTION
Вместо парсинга сообщения из alert бокса парсим url на котором произошел детект.